### PR TITLE
fix 'unterminated example block' error

### DIFF
--- a/opdrachten/hoger-lager/hoger-lager.adoc
+++ b/opdrachten/hoger-lager/hoger-lager.adoc
@@ -52,7 +52,6 @@ Tips:
 image::opdrachten/hoger-lager/opstarten1.png[]
 
 ======
-======
 
 Stap II:
 


### PR DESCRIPTION
Ran into "unterminated example block" while generating the docs, this change fixed it (note: I'm not encumbered by an asciidoc knowledge, my edit could be completely stupid!)